### PR TITLE
Add texture-base-path option

### DIFF
--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -241,6 +241,8 @@ int main(int argc, char* argv[]) {
 
   app.add_flag("--skip-texture-processing", gltfOptions.skipTextureProcessing, "Flag to skip processing textures, instead use source textures.");
 
+  app.add_option("--texture-base-path", gltfOptions.textureBasePath, "Specify an absolute texture base path.");
+
   CLI11_PARSE(app, argc, argv);
 
   bool do_flip_u = false;

--- a/src/FBX2glTF.h
+++ b/src/FBX2glTF.h
@@ -127,4 +127,6 @@ struct GltfOptions {
   std::string fbxTempDir;
 
   bool skipTextureProcessing{false};
+
+  std::string textureBasePath;
 };

--- a/src/gltf/TextureBuilder.cpp
+++ b/src/gltf/TextureBuilder.cpp
@@ -186,6 +186,11 @@ std::shared_ptr<TextureData> TextureBuilder::simple(int rawTexIndex, const std::
                                       : FileUtils::GetFileName(rawTexture.fileLocation);
 
   ImageData* image = nullptr;
+
+  if (!FileUtils::FileExists(rawTexture.fileLocation)) {
+    return nullptr;
+  }
+
   if (options.outputBinary) {
     auto bufferView = gltf.AddBufferViewForFile(*gltf.defaultBuffer, rawTexture.fileLocation);
     if (bufferView) {

--- a/src/gltf/TextureBuilder.cpp
+++ b/src/gltf/TextureBuilder.cpp
@@ -179,8 +179,10 @@ std::shared_ptr<TextureData> TextureBuilder::simple(int rawTexIndex, const std::
 
   const RawTexture& rawTexture = raw.GetTexture(rawTexIndex);
   const std::string textureName = FileUtils::GetFileBase(rawTexture.name);
+
+  const std::string base_path = options.textureBasePath.empty() ? FileUtils::GetAbsolutePath(outputFolder) : FileUtils::GetAbsolutePath(options.textureBasePath);
   const std::string relativeFilename = options.skipTextureProcessing 
-                                      ? FileUtils::GetRelativePath(FileUtils::GetAbsolutePath(rawTexture.fileLocation), FileUtils::GetAbsolutePath(outputFolder))
+                                      ? FileUtils::GetRelativePath(FileUtils::GetAbsolutePath(rawTexture.fileLocation), base_path)
                                       : FileUtils::GetFileName(rawTexture.fileLocation);
 
   ImageData* image = nullptr;


### PR DESCRIPTION
- Add a --texture-base-path option. This is so that if we are outputting the .gltf to a new file, we can ensure the texture uris will still remain relative to whatever we set as the texture-base-path. 
- Only add textures that exists. Before this check was here we were adding invalid textures