### PR TITLE
Fix generating orm textures incorrectly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,3 +8,5 @@ else
 fi
 
 conan build . -bf ${BUILD_FILE_NAME}
+
+cp "${BUILD_FILE_NAME}/FBX2glTF" "../WayveSimAssets/${BUILD_FILE_NAME}"

--- a/setup_build.sh
+++ b/setup_build.sh
@@ -25,3 +25,5 @@ conan config set general.revisions_enabled=1
 # Initialize and run build
 conan install . -i ${BUILD_FILE_NAME} -s build_type=Release ${CONAN_CONFIG} --build missing
 conan build . -bf ${BUILD_FILE_NAME}
+
+cp "${BUILD_FILE_NAME}/FBX2glTF" "../WayveSimAssets/${BUILD_FILE_NAME}"

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -246,7 +246,7 @@ ModelData* Raw2Gltf(
       TextureData* occlusionTexture = nullptr;
 
       std::shared_ptr<PBRMetallicRoughness> pbrMetRough;
-      if (options.usePBRMetRough) {
+      if (options.usePBRMetRough && !options.skipTextureProcessing) {
         // albedo is a basic texture, no merging needed
         std::shared_ptr<TextureData> baseColorTex, aoMetRoughTex;
 


### PR DESCRIPTION
- Don't create orm texture if --skip_texture_processing is set
- Copy over new binary after building