### PR TITLE
Fix missing albedo and occlusion maps

### DIFF
--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -276,7 +276,7 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  if (!gltfOptions.useKHRMatUnlit && !gltfOptions.usePBRMetRough) {
+  if (!gltfOptions.useKHRMatUnlit && !gltfOptions.usePBRMetRough && !gltfOptions.skipTextureProcessing) {
     if (verboseOutput) {
       fmt::printf("Defaulting to --pbr-metallic-roughness material support.\n");
     }

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -389,6 +389,8 @@ ModelData* Raw2Gltf(
       } else if (options.skipTextureProcessing) {
         Vec4f diffuseFactor;
         std::shared_ptr<TextureData> baseColorTex;
+        std::shared_ptr<TextureData> metallicTex;
+        std::shared_ptr<TextureData> roughnessTex;
         float metallic, roughness; 
 
         if (material.info->shadingModel == RAW_SHADING_MODEL_PBR_MET_ROUGH) {
@@ -404,9 +406,11 @@ ModelData* Raw2Gltf(
           metallic = 0.4f;
           roughness = sqrtf(2.0f / (2.0f + props->shininess));
         }
+        metallicTex = simpleTex(RAW_TEXTURE_USAGE_METALLIC);
+        roughnessTex = simpleTex(RAW_TEXTURE_USAGE_ROUGHNESS);
 
         pbrMetRough.reset(
-            new PBRMetallicRoughness(baseColorTex.get(), nullptr, diffuseFactor, metallic, roughness));
+            new PBRMetallicRoughness(baseColorTex.get(), metallicTex.get(), roughnessTex.get(), diffuseFactor, metallic, roughness));
       }
       if (!occlusionTexture) {
         occlusionTexture = simpleTex(RAW_TEXTURE_USAGE_OCCLUSION).get();

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -386,6 +386,27 @@ ModelData* Raw2Gltf(
             new PBRMetallicRoughness(baseColorTex.get(), nullptr, diffuseFactor, 0.0f, 1.0f));
 
         khrCmnUnlitMat.reset(new KHRCmnUnlitMaterial());
+      } else if (options.skipTextureProcessing) {
+        Vec4f diffuseFactor;
+        std::shared_ptr<TextureData> baseColorTex;
+        float metallic, roughness; 
+
+        if (material.info->shadingModel == RAW_SHADING_MODEL_PBR_MET_ROUGH) {
+          RawMetRoughMatProps* props = (RawMetRoughMatProps*)material.info.get();
+          diffuseFactor = props->diffuseFactor;
+          baseColorTex = simpleTex(RAW_TEXTURE_USAGE_ALBEDO);
+          metallic = props->metallic;
+          roughness = props->roughness;
+        } else {
+          RawTraditionalMatProps* props = ((RawTraditionalMatProps*)material.info.get());
+          diffuseFactor = props->diffuseFactor;
+          baseColorTex = simpleTex(RAW_TEXTURE_USAGE_DIFFUSE);
+          metallic = 0.4f;
+          roughness = sqrtf(2.0f / (2.0f + props->shininess));
+        }
+
+        pbrMetRough.reset(
+            new PBRMetallicRoughness(baseColorTex.get(), nullptr, diffuseFactor, metallic, roughness));
       }
       if (!occlusionTexture) {
         occlusionTexture = simpleTex(RAW_TEXTURE_USAGE_OCCLUSION).get();

--- a/src/gltf/properties/MaterialData.cpp
+++ b/src/gltf/properties/MaterialData.cpp
@@ -50,6 +50,20 @@ PBRMetallicRoughness::PBRMetallicRoughness(
       metallic(clamp(metallic)),
       roughness(clamp(roughness)) {}
 
+PBRMetallicRoughness::PBRMetallicRoughness(
+    const TextureData* baseColorTexture,
+    const TextureData* metallicTexture,
+    const TextureData* roughnessTexture,
+    const Vec4f& baseColorFactor,
+    float metallic,
+    float roughness) 
+    : baseColorTexture(Tex::ref(baseColorTexture)),
+      baseColorFactor(clamp(baseColorFactor)),
+      metallicTexture(Tex::ref(metallicTexture)),
+      roughnessTexture(Tex::ref(roughnessTexture)),
+      metallic(clamp(metallic)),
+      roughness(clamp(roughness)) {}
+
 void to_json(json& j, const PBRMetallicRoughness& d) {
   j = {};
   if (d.baseColorTexture != nullptr) {
@@ -65,8 +79,18 @@ void to_json(json& j, const PBRMetallicRoughness& d) {
     j["metallicFactor"] = 1.0f;
   } else {
     // without a texture, however, use metallic/roughness as constants
-    j["metallicFactor"] = d.metallic;
-    j["roughnessFactor"] = d.roughness;
+    if (d.metallicTexture) {
+      j["metallicTexture"] = *d.metallicTexture;
+      j["metallicFactor"] = 1.0f;
+    } else {
+      j["metallicFactor"] = d.metallic;
+    }
+    if (d.roughnessTexture) {
+      j["roughnessTexture"] = *d.roughnessTexture;
+      j["roughnessFactor"] = 1.0f;
+    } else {
+      j["roughnessFactor"] = d.roughness;
+    }
   }
 }
 

--- a/src/gltf/properties/MaterialData.hpp
+++ b/src/gltf/properties/MaterialData.hpp
@@ -32,8 +32,21 @@ struct PBRMetallicRoughness {
       float metallic = 0.1f,
       float roughness = 0.6f);
 
+  PBRMetallicRoughness(
+      const TextureData* baseColorTexture,
+      const TextureData* metallicTexture,
+      const TextureData* roughnessTexture,
+      const Vec4f& baseColorFactor,
+      float metallic = 0.1f,
+      float roughness = 0.6f);
+
   std::unique_ptr<Tex> baseColorTexture;
+  // combined textures
   std::unique_ptr<Tex> metRoughTexture;
+  // separate textures
+  std::unique_ptr<Tex> metallicTexture;
+  std::unique_ptr<Tex> roughnessTexture;
+
   const Vec4f baseColorFactor;
   const float metallic;
   const float roughness;


### PR DESCRIPTION
- Set the base colour texture, metallic and roughness even if not processing textures
- Don't default to a combined pbr texture if skip texture processing is set